### PR TITLE
Added a simple script to retrieve all latest AWS managed policies and examples of CloudWatch Insights and CloudTrail queries for quick lookup

### DIFF
--- a/CloudTrail/CloudTrailQueries.md
+++ b/CloudTrail/CloudTrailQueries.md
@@ -1,0 +1,78 @@
+# Some useful CloudTrail `lookup-events` queries
+
+### Notes
+See also https://docs.aws.amazon.com/en_pv/awscloudtrail/latest/userguide/view-cloudtrail-events-cli.html.
+
+1. AttributeKey` values:
+   - `AccessKeyId` (e.g. `AKIAIOSFODNN7EXAMPLE`)
+   - `EventId` (e.g. `b5cc8c40-12ba-4d08-a8d9-2bceb9a3e002`)
+   - `EventName` (e.g. `RunInstances`)
+   - `EventSource` (e.g. `iam.amazonaws.com`)
+   - `ReadOnly` (e.g. `false`)
+    - `ResourceName` (e.g. `CloudTrail_CloudWatchLogs_Role`)
+   - `ResourceType` (e.g. `AWS::S3::Bucket`)
+   - `Username` (e.g. `root`)
+
+2. [Valid `<timestamp>` formats](
+    https://docs.aws.amazon.com/awscloudtrail/latest/userguide/view-cloudtrail-events-cli.html#look-up-events-by-time-range-formats)
+
+3. CloudTrail supports logging S3 object-level API operations such as `GetObject`, `DeleteObject`, and `PutObject`.
+   These events are called data events. 
+   **However, CloudTrail trails do not log data events by default**; you need to enable S3 Object-Level Logging to
+   log data events to CloudTrail ([see REF](
+   https://docs.aws.amazon.com/AmazonS3/latest/user-guide/enable-cloudtrail-events.html)).
+
+
+### Common Queries
+
+List all event names for a given resource.
+```
+RESOURCE_ID=vol-0f59a355c2example     # EBS volume ID
+RESOURCE_ID=snap-0993c0d9a8example    # EBS snapshot ID
+
+aws cloudtrail lookup-events \
+  --lookup-attributes AttributeKey=ResourceName,AttributeValue=${RESOURCE_ID} \
+  --query 'Events[].{username:Username,time:EventTime,event:EventName,eventid:EventId,accesskey:AccessKeyId,resource:(Resources[0].ResourceName)}' \
+  --output table --region ap-southeast-2
+```
+
+List events for a specific API action for a given resource.
+```
+RESOURCE_ID=vol-0f59a355c2example     # EBS volume ID
+API_ACTION=DeleteVolume
+
+aws cloudtrail lookup-events \
+  --lookup-attributes AttributeKey=ResourceName,AttributeValue=${RESOURCE_ID} \
+  --query 'Events[].{username:Username,time:EventTime,event:EventName,eventid:EventId,accesskey:AccessKeyId,resource:(Resources[0].ResourceName)}' \
+  --output json --region ap-southeast-2 \
+  | jq -r '.[] | select(.event == "${API_ACTION}")'
+```
+
+List a specific event name for all resources.
+```
+aws cloudtrail lookup-events \
+  --lookup-attributes AttributeKey=EventName,AttributeValue=DeleteVolume \
+  --query 'Events[].{username:Username,time:EventTime,event:EventName,eventid:EventId,accesskey:AccessKeyId,resource:(Resources[0].ResourceName)}' \
+  --output table --region ap-southeast-2
+```
+
+View details for a specific event id.
+```
+EVENT_ID="0840b15f-75b5-4082-a194-86e15example"
+aws cloudtrail lookup-events \
+  --lookup-attribute AttributeKey=EventId,AttributeValue=${EVENT_ID} \
+  --query "Events[0].CloudTrailEvent" \
+  --output text --region ap-southeast-2 \
+  | jq -r '.'
+```
+
+Specify a date range
+```
+aws cloudtrail lookup-events \
+  --lookup-attributes AttributeKey=EventName,AttributeValue=DeleteVolume \
+  --query 'Events[].{username:Username,time:EventTime,event:EventName,eventid:EventId,accesskey:AccessKeyId,resource:(Resources[0].ResourceName)}' \
+  --start-time 2019-01-01T13:00Z \
+  --end-time 2019-03-01T14:00Z \
+  --output table --region ap-southeast-2
+```
+

--- a/CloudWatch/InsightsQueries.md
+++ b/CloudWatch/InsightsQueries.md
@@ -1,0 +1,219 @@
+# Some useful CloudWatch Logs Insights queries
+
+- [Common](#common)
+- [CloudTrail Logs](#cloudtrail-logs)
+- [Lambda Logs](#lambda-logs)
+- [VPC Flow Logs](#vpc-flow-logs)
+- [Route 53 Logs](#route-53-logs)
+- [AppSync Logs](#appsync-logs)
+
+See also https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax-examples.html.
+
+---
+
+### Common
+
+25 most recently added log events.
+```
+fields @timestamp, @message | sort @timestamp desc | limit 25
+```
+
+List of log events that are not exceptions.
+```
+fields @message | filter @message not like /Exception/
+```
+
+Number of exceptions logged per hour.
+```
+filter @message like /Exception/ 
+| stats count(*) as exceptionCount by bin(1h)
+| sort exceptionCount desc
+```
+
+Use a glob expression to extract the ephemeral fields @user, @method, and @latency from the log field @message and
+return the average latency for each unique combination of @method and @user.
+```
+parse @message "user=*, method:*, latency := *" as @user, @method, @latency 
+| stats avg(@latency) by @method, @user
+```
+
+Use a regular expression to extract the ephemeral fields @user2, @method2, and @latency2 from the log field @message a
+nd return the average latency for each unique combination of @method2 and @user2.
+```
+parse @message /user=(?<user2>.*?), method:(?<method2>.*?), latency := (?<latency2>.*?)/ 
+| stats avg(@latency2) by @method2, @user2
+```
+
+### CloudTrail Logs
+
+Number of log entries for each service, event type, and Region.
+```
+stats count(*) by eventSource, eventName, awsRegion
+```
+
+Number of log entries by region and EC2 event type.
+```
+filter eventSource="ec2.amazonaws.com"
+| stats count(*) as eventCount by eventName, awsRegion
+| sort eventCount desc
+```
+
+EC2 hosts that were started or stopped in a given Region.
+```
+filter (eventName="StartInstances" or eventName="StopInstances") and region="us-east-2"
+```
+
+Number of records where an exception occurred while invoking the API UpdateTrail.
+```
+filter eventName="UpdateTrail" and ispresent(errorCode)
+| stats count(*) by errorCode, errorMessage
+```
+
+Regions, usernames, and ARNs of newly created IAM users.
+```
+filter eventName="CreateUser"
+| fields awsRegion, requestParameters.userName, responseElements.user.arn
+```
+
+### Lambda Logs
+
+Determine the amount of overprovisioned memory.
+```
+filter @type = "REPORT"
+| stats max(@memorySize / 1024 / 1024) as provisonedMemoryMB,
+    min(@maxMemoryUsed / 1024 / 1024) as smallestMemoryRequestMB,
+    avg(@maxMemoryUsed / 1024 / 1024) as avgMemoryUsedMB,
+    max(@maxMemoryUsed / 1024 / 1024) as maxMemoryUsedMB,
+    provisonedMemoryMB - maxMemoryUsedMB as overProvisionedMB
+```
+
+Report latency statistics for 5-minute intervals.
+```
+filter @type = "REPORT" 
+| stats avg(@duration), max(@duration), min(@duration) by bin(5m)
+```
+
+Find the most expensive requests
+```
+filter @type = "REPORT"
+| fields @requestId, @billedDuration
+| sort by @billedDuration desc
+```
+
+### VPC Flow Logs
+
+IP addresses using UDP as a data transfer protocol.
+```
+filter protocol=17 | stats count(*) by srcAddr
+```
+
+IP addresses (top 20) with highest number of rejected requests.
+```
+filter action="REJECT"
+| stats count(*) as numRejections by srcAddr
+| sort numRejections desc | limit 20
+```
+
+Avg, min and max byte transfers by source and destination IP addresses.
+```
+stats avg(bytes), min(bytes), max(bytes) by srcAddr, dstAddr
+```
+
+Top 15 byte transfers by source and destination IP addresses.
+```
+stats sum(bytes) as bytesTransferred by srcAddr, dstAddr
+| sort bytesTransferred desc | limit 15
+```
+
+Top 15 byte transfers for a given host.
+```
+filter srcAddr LIKE "192.0.2."
+| stats sum(bytes) as bytesTransferred by dstAddr
+| sort bytesTransferred desc | limit 15
+```
+
+Top 15 packet transfers across hosts.
+```
+stats sum(packets) as packetsTransferred by srcAddr, dstAddr
+| sort packetsTransferred  desc | limit 15
+```
+
+IP addresses where flow records were skipped during the capture window.
+```
+filter logStatus="SKIPDATA"
+| stats count(*) by bin(1h) as t
+| sort t
+```
+
+### Route 53 Logs
+
+Number of requests received every 10 minutes by edge location.
+```
+stats count(*) by queryType, bin(10m)
+```
+
+Number of unsuccessful requests by domain and subdomain.
+```
+filter responseCode="SERVFAIL" | stats count(*) by queryName
+```
+
+DNS resolvers (top 10) with highest number of requests.
+```
+stats count(*) as numRequests by resolverIp
+| sort numRequests desc | limit 10
+```
+
+### AppSync Logs
+
+Number of unique HTTP status codes
+```
+fields ispresent(graphQLAPIId) as isApi
+| filter isApi | filter logType = "RequestSummary"
+| stats count() as statusCount by statusCode
+| sort statusCount desc
+```
+
+Resolvers (top 10) with maximum latency
+```
+fields resolverArn, duration
+| filter logType = "Tracing"
+| sort duration desc | limit 10
+```
+
+Most frequently invoked resolvers
+```
+fields ispresent(resolverArn) as isRes
+| stats count() as invocationCount by resolverArn
+| filter isRes | filter logType = "Tracing"
+| sort invocationCount desc | limit 10
+```
+
+Resolvers with most errors in mapping templates
+```
+fields ispresent(resolverArn) as isRes
+| stats count() as errorCount by resolverArn, logType
+| filter isRes and (logType = "RequestMapping" or logType = "ResponseMapping") and fieldInError
+| sort errorCount desc | limit 10
+```
+
+Field latency statistics
+```
+stats min(duration), max(duration), avg(duration) as avgDur by concat(parentType, '/', fieldName) as fieldKey
+| filter logType = "Tracing"
+| sort avgDur desc | limit 10
+```
+
+Resolver latency statistics
+```
+fields ispresent(resolverArn) as isRes
+| filter isRes | filter logType = "Tracing"
+| stats min(duration), max(duration), avg(duration) as avgDur by resolverArn
+| sort avgDur desc | limit 10 
+```
+
+Requests (top 10) with maximum latency
+```
+fields requestId, latency
+| filter logType = "RequestSummary"
+| sort latency desc | limit 10
+```

--- a/CloudWatch/cloudformation/CloudWatchAlarms-APIG-SnsNotification.yaml
+++ b/CloudWatch/cloudformation/CloudWatchAlarms-APIG-SnsNotification.yaml
@@ -1,0 +1,70 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  This template deploys additional CloudWatch Alarms and SNS email notifications
+  (not Auto Scaling).
+
+Parameters:
+  ApiGatewayAlarmEmail:
+    Description: Email address to notify if there are any API Gateway operational issues
+    Type: String
+  ApiName:
+    Description: Name of the API Gateway
+    Type: String
+
+Resources:
+  ApiGatewayAlarmSnsTopic:
+    Type: 'AWS::SNS::Topic'
+    Properties:
+      Subscription:
+        - Endpoint: !Ref ApiGatewayAlarmEmail
+          Protocol: email
+
+  ApiGateway4XXErrorAlarm:
+    Type: 'AWS::CloudWatch::Alarm'
+    DependsOn: ApiGatewayAlarmSnsTopic
+    Properties:
+      AlarmActions:
+        - !Ref ApiGatewayAlarmSnsTopic
+      AlarmDescription: When API Gateway 4XX error occurs it will be notified through SNS
+      AlarmName: !Join ['/', ['apigateway', !Ref ApiName, 'v1', '4XXError']]
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: ApiName
+          Value: !Ref ApiName
+        - Name: Stage
+          Value: v1
+      EvaluationPeriods: 1
+      MetricName: 4XXError
+      Namespace: AWS/ApiGateway
+      Period: 300
+      Statistic: Sum
+      Threshold: 0
+      TreatMissingData: notBreaching
+
+  ApiGateway5XXErrorAlarm:
+    Type: 'AWS::CloudWatch::Alarm'
+    DependsOn:
+      - ApiGatewayAlarmSnsTopic
+    Properties:
+      AlarmActions:
+        - !Ref ApiGatewayAlarmSnsTopic
+      AlarmDescription: When API Gateway 5XX error occurs it will be notified through SNS
+      AlarmName: !Join ['/', ['apigateway', !Ref ApiName, 'v1', '5XXError']]
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: ApiName
+          Value: !Ref ApiName
+        - Name: Stage
+          Value: v1
+      EvaluationPeriods: 1
+      MetricName: 5XXError
+      Namespace: AWS/ApiGateway
+      Period: 300
+      Statistic: Sum
+      Threshold: 0
+      TreatMissingData: notBreaching
+
+Outputs:
+  ApiGatewayAlarmSnsTopicArn:
+    Description: A reference to SNS Notification ARN of API Gateway error activities
+    Value: !Ref ApiGatewayAlarmSnsTopic

--- a/CloudWatch/cloudformation/CloudWatchAlarms-Lambda-SnsNotification.yaml
+++ b/CloudWatch/cloudformation/CloudWatchAlarms-Lambda-SnsNotification.yaml
@@ -1,0 +1,78 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  This template deploys additional CloudWatch Alarms and SNS email notifications
+  (not Auto Scaling).
+
+Parameters:
+  LambdaAlarmEmail:
+    Description: Email address to notify if there are any Lambda operational issues
+    Type: String
+  LambdaAlias:
+    Description: Lambda alias for a deployment stage.
+    Type: String
+    AllowedValues:
+      - V1
+      - STAGING
+      - DEV
+    Default: DEV
+  LambdaFunctionName:
+    Description: name of the  Lambda function.
+    Type: String
+
+Resources:
+  LambdaAlarmSnsTopic:
+    Type: 'AWS::SNS::Topic'
+    Properties:
+      Subscription:
+        - Endpoint: !Ref LambdaAlarmEmail
+          Protocol: email
+
+  LambdaErrorsAlarm:
+    Type: 'AWS::CloudWatch::Alarm'
+    DependsOn: LambdaAlarmSnsTopic
+    Properties:
+      AlarmActions:
+        - !Ref LambdaAlarmSnsTopic
+      AlarmDescription: When Lambda error occurs it will be notified through SNS
+      AlarmName: !Join ['/', [!Ref LambdaFunctionName, !Ref LambdaAlias, 'LambdaErrors']]
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref LambdaFunctionName
+        - Name: Resource
+          Value: !Join [':', [!Ref LambdaFunctionName, !Ref LambdaAlias]]
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Sum
+      Threshold: 0
+      TreatMissingData: notBreaching
+
+  LambdaThrottlesAlarm:
+    Type: 'AWS::CloudWatch::Alarm'
+    DependsOn:
+      - LambdaAlarmSnsTopic
+    Properties:
+      AlarmActions:
+        - !Ref LambdaAlarmSnsTopic
+      AlarmDescription: When Lambda throttle occurs it will be notified through SNS
+      AlarmName: !Join ['/', [!Ref LambdaFunctionName, !Ref LambdaAlias, 'LambdaThrottles']]
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref LambdaFunctionName
+        - Name: Resource
+          Value: !Join [':', [!Ref LambdaFunctionName, !Ref LambdaAlias]]
+      EvaluationPeriods: 1
+      MetricName: Throttles
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Sum
+      Threshold: 0
+      TreatMissingData: notBreaching
+
+Outputs:
+  LambdaAlarmSnsTopicArn:
+    Description: A reference to SNS Notification ARN of Lambda error activities
+    Value: !Ref LambdaAlarmSnsTopic

--- a/CloudWatch/cloudformation/SubscriptionFilter-CloudWatchEcsLogGroup.yaml
+++ b/CloudWatch/cloudformation/SubscriptionFilter-CloudWatchEcsLogGroup.yaml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Create CloudWatch Log Subscription Filter and LambdaInvokePermission for a Lambda function.
+
+Parameters:
+  CloudWatchEcsLogGroupName:
+    Description: Name of CloudWatch Log Group the Lambda Function to be invoked from
+    Type: String
+    Default: ECS/Simple-Service-Dev
+  LambdaAlias:
+    Description: Lambda alias for a deployment stage.
+    Type: String
+    AllowedValues:
+      - V1
+      - STAGING
+      - DEV
+    Default: DEV
+  LambdaArn:
+    Description: ARN of the  Lambda function to be created or updated.
+    Type: String
+
+Resources:
+  SubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      LogGroupName: !Ref CloudWatchEcsLogGroupName
+      FilterPattern: ''
+      DestinationArn: !Join [':', [!Ref LambdaArn, !Ref LambdaAlias]]
+
+  LambdaInvokePermission:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      FunctionName: !Join [':', [!Ref LambdaArn, !Ref LambdaAlias]]
+      Action: 'lambda:InvokeFunction'
+      Principal: !Sub 'logs.${AWS::Region}.amazonaws.com'
+      SourceAccount: !Ref 'AWS::AccountId'
+      SourceArn: !Sub
+        - 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${LogGroupName}:*'
+        - {LogGroupName: !Ref CloudWatchEcsLogGroupName}
+
+Outputs:
+  SubscriptionFilter:
+    Description: The logical ID of the SubscriptionFilter
+    Value: !Ref SubscriptionFilter
+
+  LambdaInvokePermission:
+    Description: The logical ID of the LambdaInvokePermission
+    Value: !Ref LambdaInvokePermission

--- a/IAM/aws_managed_policies.sh
+++ b/IAM/aws_managed_policies.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Retrieve all AWS Managed IAM policies
+# See also https://github.com/SummitRoute/aws_managed_policies
+
+# Set to fail script if any command fails.
+set -e
+function finish {
+  [[ -f list-policies.json ]] && rm list-policies.json
+}
+trap finish EXIT
+
+rm -rf "aws_managed_policies"
+mkdir -p "aws_managed_policies"
+
+aws iam list-policies > list-policies.json
+
+(jq -cr '.Policies[] | select(.Arn | contains("iam::aws"))|.Arn +" "+ .DefaultVersionId+" "+.PolicyName' | \
+ xargs -n3 sh -c 'aws iam get-policy-version --policy-arn $0 --version-id $1 > aws_managed_policies/$2.json') \
+< list-policies.json


### PR DESCRIPTION
1. Added a simple script to retrieve all latest AWS managed policies and save them in individual files
2. Put up a list of examples and common CloudWatch Logs Insights queries for quick lookup
3. Put up a list of examples and common CloudTrail queries for quick lookup