### PR TITLE
Fixed cross-account bucket policy and kms policy

### DIFF
--- a/S3/cross-account-bucket-with-kms/cloudformation/account_A_s3_bucket_and_role_and_policy.yaml
+++ b/S3/cross-account-bucket-with-kms/cloudformation/account_A_s3_bucket_and_role_and_policy.yaml
@@ -15,11 +15,11 @@ Parameters:
     Type: String
     Default: k-shared-cross-account-bucket-readonly-role
   AccountBUserArn:
-    Description: The ARN of a role in account B for uploading files to the shared bucket in account A
+    Description: The ARN of the root in account B for uploading files to the shared bucket in account A
     Type: String
-    Default: arn:aws:iam::222222222222:user/cross-account-s3-upload
+    Default: arn:aws:iam::222222222222:root
   AccountCUserArn:
-    Description: The ARN of a the root of account C as the principal for downloading B's files from the shared bucket in account A
+    Description: The ARN of the root of account C as the principal for downloading B's files from the shared bucket in account A
     Type: String
     Default: arn:aws:iam::333333333333:root
 
@@ -78,11 +78,14 @@ Resources:
               AWS:
                 - !GetAtt IamRole.Arn
                 - !Ref AccountBUserArn
+                # - "arn:aws:iam::109876543210:user/User1"    # parent account
+                # - "arn:aws:iam::012345678901:root"          # external account
             Action:
               - kms:Decrypt
               - kms:DescribeKey
               - kms:Encrypt
               - kms:GenerateDataKey*
+              - kms:ReEncrypt*
             Resource: "*"
 
   KmsAlias:
@@ -123,7 +126,9 @@ Resources:
         - Effect: Allow
           Principal:
             AWS:
-            - !Ref AccountBUserArn
+              - !Ref AccountBUserArn
+              # - "arn:aws:iam::109876543210:user/User1"    # parent account
+              # - "arn:aws:iam::012345678901:root"          # external account
           Action:
             - s3:PutObject
             - s3:PutObjectAcl
@@ -169,9 +174,9 @@ Resources:
           # permission on the key policy for the download to work.
           - Effect: Allow
             Action:
-              - kms:DescribeKey
-              - kms:Encrypt
               - kms:Decrypt
+              - kms:DescribeKey
+              - kms:GenerateDataKey*
             Resource:
               - !GetAtt KmsKey.Arn
       Roles:

--- a/S3/cross-account-bucket-with-kms/cloudformation/account_B_iam_assume_role_policy.yaml
+++ b/S3/cross-account-bucket-with-kms/cloudformation/account_B_iam_assume_role_policy.yaml
@@ -62,7 +62,9 @@ Resources:
           Action:
             - kms:Decrypt
             - kms:DescribeKey
-            - kms:Encrypy
+            - kms:Encrypt
+            - kms:GenerateDataKey*
+            - kms:ReEncrypt*
           Resource:
             - !Ref KmsArn
       Users:

--- a/S3/cross-account-bucket-with-kms/cloudformation/test.sh
+++ b/S3/cross-account-bucket-with-kms/cloudformation/test.sh
@@ -13,7 +13,6 @@ trap finish EXIT
 # TODO Change these
 AWS_PROFILE_UPLOAD="account-b"
 AWS_PROFILE_DOWNLOAD="account-c"
-
 BUCKET_NAME="k-shared-cross-account-bucket"
 IAM_ASSUME_ROLE="arn:aws:iam::111111111111:role/k-shared-cross-account-bucket-readonly-role"
 KMS_ALIAS_ARN="arn:aws:kms:ap-southeast-2:111111111111:alias/${BUCKET_NAME}-kms"


### PR DESCRIPTION
Fixed cross-account bucket policy and kms policy

1. Fixed ARN of external account in Bucket policy and KMS policy
2. Fixed kms actions im managed policies of account A and account B

Tested with `S3/cross-account-bucket-with-kms/cloudformation/test.sh`